### PR TITLE
マジックドレッサーインベントリでマテリアル変更待機秒数を0に近づけた場合無限ループで止まる問題の修正

### DIFF
--- a/Assets/HhotateA/AvatarModifyTool/Editor/AnimationClipCreator.cs
+++ b/Assets/HhotateA/AvatarModifyTool/Editor/AnimationClipCreator.cs
@@ -146,7 +146,7 @@ namespace HhotateA.AvatarModifyTools.Core
             if (objectReferenceKeyframes.ContainsKey(target))
             {
                 // 時間重複したキーフレーム防止策
-                while (objectReferenceKeyframes[target].Any(f => Mathf.Abs(f.time - time)<1f/60f))
+                while (objectReferenceKeyframes[target].Any(f => Mathf.Abs(f.time - frame.time)<1f/60f))
                 {
                     frame.time += 1f / 60f;
                 }


### PR DESCRIPTION
こんな感じでmaterialのDelayを0にするとUnityが応答しなくなる問題の修正
![image](https://user-images.githubusercontent.com/1712548/154814467-7a0ca216-a7eb-4e29-bdb1-cc835e5034bb.png)
