### PR TITLE
Modular Avatar対応

### DIFF
--- a/Assets/HhotateA/AvatarModifyTool/Editor/MA.meta
+++ b/Assets/HhotateA/AvatarModifyTool/Editor/MA.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a9b47c9ce37f23e4eb267e0ccf113094
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HhotateA/AvatarModifyTool/Editor/MA/HhotateA.AvatarModifyTools.Core.MA.asmdef
+++ b/Assets/HhotateA/AvatarModifyTool/Editor/MA/HhotateA.AvatarModifyTools.Core.MA.asmdef
@@ -1,0 +1,34 @@
+{
+    "name": "HhotateA.AvatarModifyTools.Core.MA",
+    "rootNamespace": "",
+    "references": [
+        "nadena.dev.modular-avatar.core"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "nadena.dev.modular-avatar",
+            "expression": "1",
+            "define": "HAS_MA"
+        },
+        {
+            "name": "nadena.dev.modular-avatar",
+            "expression": "1.5",
+            "define": "HAS_MA_1_5"
+        },
+        {
+            "name": "nadena.dev.modular-avatar",
+            "expression": "1.9",
+            "define": "HAS_MA_1_9"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/Assets/HhotateA/AvatarModifyTool/Editor/MA/HhotateA.AvatarModifyTools.Core.MA.asmdef.meta
+++ b/Assets/HhotateA/AvatarModifyTool/Editor/MA/HhotateA.AvatarModifyTools.Core.MA.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b9233dcf70dd8244f89e6184c89eaa54
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HhotateA/AvatarModifyTool/Editor/MA/ModularAvatarUtil.cs
+++ b/Assets/HhotateA/AvatarModifyTool/Editor/MA/ModularAvatarUtil.cs
@@ -1,0 +1,115 @@
+using UnityEngine;
+using UnityEditor;
+using UnityEditor.Animations;
+#if VRC_SDK_VRCSDK3
+using VRC.SDK3.Avatars.Components;
+using VRC.SDK3.Avatars.ScriptableObjects;
+#endif
+#if HAS_MA
+using nadena.dev.modular_avatar.core;
+#endif
+using System.Linq;
+using System;
+
+namespace HhotateA.AvatarModifyTools.Core
+{
+    public static class ModularAvatarUtil
+    {
+#if HAS_MA
+        public static bool MAEnabled => true;
+
+        public static void MergeAnimatorController(GameObject go, VRCAvatarDescriptor.AnimLayerType animLayerType, AnimatorController animatorController)
+        {
+            var mergeAnimators = go.GetComponents<ModularAvatarMergeAnimator>();
+            var mergeAnimator = mergeAnimators.FirstOrDefault(ma => ma.layerType == animLayerType);
+            if (mergeAnimator == null)
+            {
+                if (animatorController == null)
+                {
+                    return;
+                }
+                mergeAnimator = go.AddComponent<ModularAvatarMergeAnimator>();
+                mergeAnimator.layerType = animLayerType;
+                Undo.RegisterCreatedObjectUndo(mergeAnimator, "Merge Animator Controller");
+            }
+            else
+            {
+                if (animatorController == null)
+                {
+                    Undo.DestroyObjectImmediate(mergeAnimator);
+                    return;
+                }
+                Undo.RecordObject(mergeAnimator, "Merge Animator Controller");
+            }
+            mergeAnimator.animator = animatorController;
+            mergeAnimator.pathMode = MergeAnimatorPathMode.Absolute;
+            mergeAnimator.matchAvatarWriteDefaults = true;
+        }
+
+        public static void MenuInstaller(GameObject go, VRCExpressionsMenu menu)
+        {
+            var menuInstaller = go.GetComponent<ModularAvatarMenuInstaller>();
+            if (menuInstaller == null)
+            {
+                menuInstaller = go.AddComponent<ModularAvatarMenuInstaller>();
+                Undo.RegisterCreatedObjectUndo(menuInstaller, "Menu Installer");
+            }
+            else
+            {
+                Undo.RecordObject(menuInstaller, "Menu Installer");
+            }
+            menuInstaller.menuToAppend = menu;
+        }
+
+        public static void Parameter(GameObject go, VRCExpressionParameters parameters)
+        {
+            var maParameters = go.GetComponent<ModularAvatarParameters>();
+            if (maParameters == null)
+            {
+                maParameters = go.AddComponent<ModularAvatarParameters>();
+                Undo.RegisterCreatedObjectUndo(maParameters, "Parameters");
+            }
+            else
+            {
+                Undo.RecordObject(maParameters, "Parameters");
+            }
+            maParameters.parameters.Clear();
+            foreach (var parameter in parameters.parameters)
+            {
+                maParameters.parameters.Add(new ParameterConfig
+                {
+                    nameOrPrefix = parameter.name,
+                    saved = parameter.saved,
+                    syncType = parameter.valueType.SyncType(),
+                    defaultValue = parameter.defaultValue,
+#if HAS_MA_1_9
+                    hasExplicitDefaultValue = true,
+#endif
+#if HAS_MA_1_5
+                    localOnly = !parameter.networkSynced,
+#endif
+                });
+            }
+        }
+
+        static ParameterSyncType SyncType(this VRCExpressionParameters.ValueType parameterValueType)
+        {
+            switch (parameterValueType)
+            {
+                case VRCExpressionParameters.ValueType.Int: return ParameterSyncType.Int;
+                case VRCExpressionParameters.ValueType.Float: return ParameterSyncType.Float;
+                case VRCExpressionParameters.ValueType.Bool: return ParameterSyncType.Bool;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(parameterValueType), parameterValueType, null);
+            }
+        }
+#else
+        public static bool MAEnabled => false;
+#if VRC_SDK_VRCSDK3
+        public static void MergeAnimatorController(GameObject go, VRCAvatarDescriptor.AnimLayerType animLayerType, AnimatorController animatorController) { }
+        public static void MenuInstaller(GameObject go, VRCExpressionsMenu menu) { }
+        public static void Parameter(GameObject go, VRCExpressionParameters parameters) { }
+#endif
+#endif
+    }
+}

--- a/Assets/HhotateA/AvatarModifyTool/Editor/MA/ModularAvatarUtil.cs.meta
+++ b/Assets/HhotateA/AvatarModifyTool/Editor/MA/ModularAvatarUtil.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eec3ea706608957468b2cabf9966c5a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HhotateA/EmoteMotionKit/Editor/EmoteMotionKitSetup.cs
+++ b/Assets/HhotateA/EmoteMotionKit/Editor/EmoteMotionKitSetup.cs
@@ -61,6 +61,8 @@ namespace HhotateA.AvatarModifyTools.EmoteMotionKit
         ReorderableList emoteReorderableList;
         
         private EmoteMotionKitSaveData data;
+
+        private bool useMA = true;
         
         Vector2 scroll = Vector2.zero;
 
@@ -244,6 +246,12 @@ namespace HhotateA.AvatarModifyTools.EmoteMotionKit
             }
             EditorGUILayout.Space();
             EditorGUILayout.Space();
+
+            if (ModularAvatarUtil.MAEnabled)
+            {
+                useMA = EditorGUILayout.Toggle("Use Modular Avatar", useMA);
+                EditorGUILayout.Space();
+            }
 
             if (GUILayout.Button("Setup"))
             {
@@ -465,7 +473,15 @@ namespace HhotateA.AvatarModifyTools.EmoteMotionKit
                 }
             }
             AssetDatabase.AddObjectToAsset(assets,path);
-            ApplySettings(mod).ModifyAvatar(assets,EnvironmentGUIDs.prefix);
+            mod = ApplySettings(mod);
+            if (useMA && ModularAvatarUtil.MAEnabled)
+            {
+                mod.ModifyAvatarByMA(assets, EnvironmentGUIDs.prefix);
+            }
+            else
+            {
+                mod.ModifyAvatar(assets, EnvironmentGUIDs.prefix);
+            }
 #endif
         }
 


### PR DESCRIPTION
related #76

既存のセーブデータをそのままに、それをMA Merge Animator等で結合するような共通メソッドを作りました。

ものによってMAにスムーズに出来る物と出来ないものがあるとは思いますが、手始めに今ひとつ良い代替がまだ出ていないEmoteMotionKitへの適用をしてみました。

- Modular Avatar 1.1.1以降一応どれでも動くはず
- Modular Avatarなくても動くはず
- MAがないVRCSDK2でもたぶん動くはず……